### PR TITLE
fix: .gitignore 오류 정정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .DS_Store
-/vscode
+/.vscode
 /src/service/SERVICE_KEY.js


### PR DESCRIPTION

- /vscode => /.vscode
# .gitignore 파일 수정

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- .gitignore

## [📝 생성된 파일]

- 없음

## [📌 제안 사항]

- 없음

## [📢 Notice]

- live server 사용시 기본 PORT Setting 용으로 생성되는 폴더의 업로드를 제한하기 위하여 /.vscode 폴더를 gitignore에 추가하였습니다.