### PR TITLE
style: 빠른 예매 페이지 - 레이아웃 구현

### DIFF
--- a/src/pages/selectTheaterPage.html
+++ b/src/pages/selectTheaterPage.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>가나다라영화사</title>
+    <!-- font-awesome -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css"
+    />
+    <link rel="stylesheet" href="../styles/reset.css" />
+    <link rel="stylesheet" href="../styles/components/header.css" />
+    <link rel="stylesheet" href="../styles/components/footer.css" />
+    <link rel="stylesheet" href="../styles/components/main.css" />
+    <link rel="stylesheet" href="../styles/components/aside.css" />
+  </head>
+
+  <body>
+    <header id="header">
+      <h1 class="tit">
+        <img class="tit-logo" src="../img/logo.png" alt="가나다라영화사" />
+      </h1>
+      <nav class="tit-nav">
+        <ul class="tit-nav-list">
+          <li>
+            <a href="#">최신영화</a>
+          </li>
+          <li>
+            <a href="#">추천영화</a>
+          </li>
+          <li>
+            <a href="#">빠른예매</a>
+          </li>
+          <li>
+            <a href="#" target="_blank">고객센터</a>
+          </li>
+        </ul>
+      </nav>
+      <!-- 로그인 버튼 - 대엽님이 수정 -->
+      <div class="tit-btn-wrap">
+        <a href="login.html" target="_blank">로그인</a>
+      </div>
+    </header>
+
+    <main id="main">
+      <aside id="aside">
+        <button class="hide-aside-btn">
+          <i class="fas fa-angle-double-left"></i>
+        </button>
+        <div class="ticketing">
+          <h2 class="ticketing-tit">빠른 예매</h2>
+          <div class="ticketing-member">
+            <button class="ticketing-steps-btn active" type="button">
+              <i class="fas fa-angle-down"></i> 회원 예매
+            </button>
+            <ul class="ticketing-steps active">
+              <li>영화정보 선택</li>
+              <li>결제하기</li>
+              <li>결제내역 확인</li>
+            </ul>
+          </div>
+          <div class="ticketing-visitor">
+            <button class="ticketing-steps-btn" type="button">
+              <i class="fas fa-angle-right"></i> 비회원 예매
+            </button>
+            <ul class="ticketing-steps">
+              <li>개인정보활용동의</li>
+              <li>영화정보 선택</li>
+              <li>결제하기</li>
+              <li>결제내역 확인</li>
+            </ul>
+          </div>
+        </div>
+      </aside>
+
+      <section class="info">
+        <h2 class="ir">영화정보 선택</h2>
+        <a class="before-link" href="#"
+          ><i class="fas fa-arrow-circle-left"></i> 뒤로 가기</a
+        >
+        <div class="info-container">
+          <h2 class="info-tit">영화정보선택 &gt; 상영관 선택</h2>
+        </div>
+      </section>
+    </main>
+
+    <footer id="footer">
+      <div class="floor-wrap">
+        <h2>
+          <img
+            class="tit-logo"
+            src="../img/logo_black.png"
+            alt="가나다라영화사"
+          />
+        </h2>
+        <ul class="icon-list">
+          <li>
+            <a href="#"><img src="../img/twitter.png" alt="트위터" /></a>
+          </li>
+          <li>
+            <a href="#"><img src="../img/instagram.png" alt="인스타그램" /></a>
+          </li>
+          <li>
+            <a href="#"><img src="../img/facebook.png" alt="페이스북" /></a>
+          </li>
+        </ul>
+      </div>
+      <div class="floor-wrap">
+        <dl class="floor-info">
+          <dt class="ir">회사 이름</dt>
+          <dd>(주)가나다라영화사</dd>
+          <dt>대표</dt>
+          <dd>멋쟁이사자</dd>
+          <dt>사업자 번호</dt>
+          <dd>000-0000-0000</dd>
+          <dt class="ir">업종</dt>
+          <dd>영화 콘텐츠 정보</dd>
+          <dt>주소</dt>
+          <dd>서울특별시</dd>
+        </dl>
+        <p class="copy-right">© 2022 벌써열두시</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/src/styles/components/aside.css
+++ b/src/styles/components/aside.css
@@ -1,0 +1,98 @@
+#aside {
+  position: relative;
+  width: 250px;
+  background-color: #339eb2;
+  color: #fff;
+}
+
+.hide-aside-btn {
+  display: none;
+  position: absolute;
+  top: 0px;
+  left: 200px;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 36px;
+}
+
+.ticketing {
+  min-width: 200px;
+  padding-top: 60px;
+  padding-left: 50px;
+  /* temp */
+  /* footer의 상단이 viewport height 하단과 일치하도록 하는 방법 */
+  /* padding-bottom: calc(100vh - 25em); */
+  /* footer의 하단이 viewport height 하단과 일치하도록 하는 방법  */
+  padding-bottom: calc(100vh - 41em);
+}
+
+.ticketing .ticketing-tit {
+  margin-bottom: 20px;
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1.7;
+}
+
+.ticketing-member,
+.ticketing-visitor {
+  margin-top: 10px;
+}
+
+.ticketing-member .ticketing-steps-btn,
+.ticketing-visitor .ticketing-steps-btn {
+  margin: 10px 0;
+  padding: 0;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.ticketing-member .ticketing-steps-btn.active,
+.ticketing-visitor .ticketing-steps-btn.active {
+  color: #711bff;
+}
+
+.ticketing-steps-btn.active::after {
+  content: ' ';
+}
+
+.ticketing-steps-btn .fa-angle-right {
+  margin-right: 8px;
+  font-size: 20px;
+  color: #fff;
+}
+
+.ticketing-steps-btn.active .fa-angle-down {
+  margin-right: 8px;
+  font-size: 20px;
+  color: #711bff;
+}
+
+.ticketing .ticketing-steps {
+  display: none;
+}
+
+.ticketing .ticketing-steps.active {
+  display: block;
+}
+
+.ticketing .ticketing-steps li {
+  margin-left: 24px;
+  font-size: 16px;
+  line-height: 2.4;
+}
+
+.ticketing .ticketing-steps.active li:nth-child(1) {
+  color: #f8fa80;
+  font-weight: 700;
+}
+
+@media screen and (max-width: 1080px) {
+  .hide-aside-btn {
+    display: block;
+  }
+}

--- a/src/styles/components/main.css
+++ b/src/styles/components/main.css
@@ -1,0 +1,35 @@
+#main {
+  display: flex;
+}
+
+.info {
+  position: relative;
+  width: 70em;
+  height: 56em;
+  min-width: 40em;
+  min-height: 40em;
+  margin: auto;
+  margin-top: 40px;
+}
+
+.before-link {
+  display: inline-block;
+  margin-top: 10px;
+  margin-bottom: 10px;
+  margin-left: 24px;
+}
+
+.info-container {
+  width: 68rem;
+  height: 52rem;
+  background: #ffffff;
+  margin: 10px 24px;
+  border-radius: 10px;
+  box-shadow: 6px 6px 20px rgba(0, 0, 0, 0.1);
+}
+
+.info-tit {
+  padding: 20px;
+  font-size: 24px;
+  font-weight: 500;
+}


### PR DESCRIPTION
# 빠른 예매 (상영관 선택)페이지 - 레이아웃 구현

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- 없음

## [📝 생성된 파일]

- src/pages/selectTheaterPage.html
- src/styles/components/main.css
- src/styles/components/aside.css

## [📌 제안 사항]

- footer 부분을 사용자에게 나타낼 것인지 아닌지 고려해야할 것 같습니다. (cgv는 의도적으로 페이지의 height를 늘려서 스크롤링하여 내리지 않는 이상 footer가 보이지 않도록 설정하였습니다.)
- aside 부분에서 미디어쿼리를 이용하여 일정 viewport width 이하면 숨김처리가 되도록 효과를 주는 것이 좋을 것 같습니다.
- 애니메이션 효과를 적용해야할 듯 합니다.
- 후에 다시 숨김처리된 aside를 불러오는 방법으로 기존 aside 영역 근처로 마우스 포인터가 이동하면 자동으로 천천히 aside가 표기되도록 하는 방식을 생각해보았습니다. (JS 적용 필요)
## [📢 Notice]

- font-awesome 사용하였음 (v.5.15.4) => selectTheaterPage.html만 적용되었음
- aside는 사용자의 현재 진행 상황을 표기
- aside를 통해 빠른 예매 안에서의 내부 메뉴 확인 가능
- section에서 예매에 필요한 정보를 제공할 예정
- section에서 뒤로가기 링크를 클릭하면 이전 페이지로 이동할 수 있도록 함