### PR TITLE
feat: 빠른 예매 페이지 슬라이드 구현

### DIFF
--- a/src/js/ticketingPageOverall.js
+++ b/src/js/ticketingPageOverall.js
@@ -1,0 +1,26 @@
+const ticketingPage = document.querySelector('.ticketing');
+const progressBar = ticketingPage.querySelector('.progress-list');
+const ticketingSlide = ticketingPage.querySelector(
+  '.ticketing-slide-container'
+);
+
+const stepArr = progressBar.children;
+const tagArr = [
+  'select_theater',
+  'select_movie',
+  'select_payment',
+  'select_bill',
+];
+
+Array.prototype.forEach.call(stepArr, (step) => {
+  step.addEventListener('click', function (e) {
+    const selectedLiTag = e.currentTarget.dataset.tag;
+    console.log(selectedLiTag);
+    tagArr.forEach((tagName, idx) => {
+      if (tagName === selectedLiTag) {
+        ticketingSlide.style.position = 'relative';
+        ticketingSlide.style.right = `calc(68rem * ${idx})`;
+      }
+    });
+  });
+});

--- a/src/pages/ticketingPage.html
+++ b/src/pages/ticketingPage.html
@@ -15,6 +15,7 @@
     <link rel="stylesheet" href="../styles/components/footer.css" />
     <link rel="stylesheet" href="../styles/components/main.css" />
     <link rel="stylesheet" href="../styles/ticketingPage.css">
+    <script src="../js/ticketingPageOverall.js" defer></script>
   </head>
 
   <body>
@@ -48,25 +49,25 @@
       <section class="ticketing">
         <h2 class="ticketing-tit ir">빠른 예매</h2>
         <ul class="progress-list">
-          <li class="fulfilled">
+          <li class="fulfilled" data-tag="select_theater">
             상영관 선택
             <div class="bar">
               <div class="value"></div>
             </div>
           </li>
-          <li class="standby">
+          <li class="standby" data-tag="select_movie">
             영화 선택
             <div class="bar">
               <div class="value"></div>
             </div>
           </li>
-          <li class="standby">
+          <li class="standby" data-tag="select_payment">
             결제하기
             <div class="bar">
               <div class="value"></div>
             </div>
           </li>
-          <li class="standby">
+          <li class="standby" data-tag="select_bill">
             결제내역 확인 및 취소
             <div class="bar">
               <div class="value"></div>

--- a/src/styles/ticketingPage.css
+++ b/src/styles/ticketingPage.css
@@ -1,6 +1,7 @@
 .ticketing {
     width: 70em;
     margin: 50px auto;
+    overflow: hidden;
 }
 .prev-btn {
     all : unset;


### PR DESCRIPTION
# feat: 빠른 예매 페이지 슬라이드 구현

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- src/pages/ticketingPage.html
- src/styles/ticketingPage.css

## [📝 생성된 파일]

- src/js/ticketingPageOverall.js

## [📌 제안 사항]

- 없음

## [📢 Notice]

- ticketingPage 슬라이드를 구현했습니다. 상단의 progress bar를 클릭하면 해당 슬라이드로 이동합니다.