### PR TITLE
fix: 이미지를 불러올 수 없는 경우 대체 이미지로 변경

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -42,7 +42,7 @@ window.addEventListener("DOMContentLoaded", async () => {
 
     $newItemLi.innerHTML = `
     <div class="newItem-wrap">
-    <img class="newItem-img" src=${resultObj.image}>
+    <img class="newItem-img" src=${resultObj.image || replaceImg}>
     <p class="newItem-name">${resultObj.title}</p>
     <div class="desc-wrap">
       <dl class="type-wrap">


### PR DESCRIPTION
# fix: 이미지를 불러올 수 없는 경우 대체 이미지로 변경
#62

## [🖥️ 스크린샷]

![image](https://user-images.githubusercontent.com/90930391/210031178-1e537e57-a43a-4e49-8ce0-db8c1dbe5f2a.png)

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- src/js/main.js

## [📝 생성된 파일]

- 없음

## [📌 제안 사항]

- 모두에게 제안하고 싶은 내용을 작성하여 주세요.
- 해당 안건은 회의시간 안건으로 사용됩니다.

## [📢 Notice]

- onerror를 img 요소 안에 넣어 오류를 해결하는 방식보다는 OR 연산자의 특징인 앞이 false이면 뒤에 있는 true 값을 바라보게 만드는 것을 이용하여 문제를 해결함

## [이슈 끝내기]
close: #62
