### PR TITLE
fix: mainPage 디자인 개선

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -26,12 +26,7 @@ function filterReg(title) {
 }
 
 const $newItems = document.querySelector(".newItems");
-// const $newItemLis = document.querySelectorAll(".newItems > li");
 const replaceImg = "https://unsplash-assets.imgix.net/empty-states/photos.png";
-// const $movieTitle = $newItems.querySelector(".newItem-name");
-// const $movieImg = $newItems.querySelector(".newItem-img");
-// const $movieDate = $newItems.querySelector(".type-wrap .date");
-// const $movieActor = $newItems.querySelector(".type-wrap .actor");
 
 window.addEventListener("DOMContentLoaded", async () => {
   const boxOfficeMovieInfoArr = await getMovieData();
@@ -42,20 +37,22 @@ window.addEventListener("DOMContentLoaded", async () => {
 
     $newItemLi.innerHTML = `
     <div class="newItem-wrap">
-    <img class="newItem-img" src=${resultObj.image || replaceImg}>
-    <p class="newItem-name">${resultObj.title}</p>
-    <div class="desc-wrap">
-      <dl class="type-wrap">
-        <dt class="type-b">개봉</dt>
-        <dd class="date">${resultObj.date}</dd>
-      </dl>
-      <dl class="type-wrap">
-        <dt class="type-c">출연</dt>
-        <dd class="actor">${resultObj.actor}</dd>
-      </dl>
+      <div class="img-wrap">
+        <img class="newItem-img" src=${resultObj.image || replaceImg} />
+      </div>
+      <p class="newItem-name">${resultObj.title}</p>
+      <div class="desc-wrap">
+        <dl class="open-wrap">
+          <dt class="type-b">개봉</dt>
+          <dd class="date">${resultObj.date}</dd>
+        </dl>
+        <dl class="actor-wrap">
+          <dt class="type-c">출연</dt>
+          <dd class="actor">${resultObj.actor}</dd>
+        </dl>
+      </div>
     </div>
-  </div>
-  <div class="fast-ticket"><a href="#빠른예매페이지">예매하기</a></div>
+    <div class="fast-ticket"><a href="#빠른예매페이지">예매하기</a></div>
     `;
 
     $newItems.appendChild($newItemLi);

--- a/src/pages/mainPage.html
+++ b/src/pages/mainPage.html
@@ -40,7 +40,7 @@
       <a class="login-btn" href="login.html" target="_blank">로그인</a>
     </div>
   </header>
-  <main id="main">
+  <main id="main" class="main-wrap">
     <h2 class="ir">최신영화목록</h2>
     <div class="main-tit-wrap">
       <p class="main-tit-txt">가나다라 주간 박스 오피스</p>

--- a/src/styles/components/main.css
+++ b/src/styles/components/main.css
@@ -13,7 +13,7 @@
 }
 .newItems {
   border: 2px solid #bdbdbd;
-  width: 1000px;
+  max-width: 1000px;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -22,7 +22,9 @@
   border-radius: 10px;
 }
 
-.newItems li{
+.newItems li {
+  width: 220px;
+  margin-bottom: auto;
   border: 2px solid #bdbdbd;
   border-radius: 10px;
   overflow: hidden;
@@ -48,21 +50,39 @@
 .newItem-name {
   font-size: 26px;
   font-weight: 700;
+  display: inline;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
-.des-wrap {
+.desc-wrap {
   display: flex;
   flex-direction: column;
   gap: 5px;
 }
-.genre-wrap, .open-wrap, .actor-wrap {
+.genre-wrap,
+.open-wrap,
+.actor-wrap {
   display: flex;
   flex-direction: row;
   gap: 5px;
   font-size: 13px;
 }
-.genre-wrap dt, .open-wrap dt, .actor-wrap dt {
+.genre-wrap dt,
+.open-wrap dt,
+.actor-wrap dt {
   color: #bdbdbd;
 }
+.genre,
+.date,
+.actor {
+  width: 140px;
+  display: inline-block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
 .fast-ticket {
   padding: 9px 27px 12px 27px;
   text-align: center;


### PR DESCRIPTION
# (커밋 메시지 헤더와 동일하게 작성)
#64

## [🖥️ 스크린샷]

- text-overflow: ellipse를 적용하여 말줄임 사용에 따른 디자인 개선

![image](https://user-images.githubusercontent.com/90930391/210032920-ad16d3d5-5fdb-4703-a0ae-f5bf097bf488.png)

- 브라우저 viewport width에 따른 자연스러운 UI 구성

![image](https://user-images.githubusercontent.com/90930391/210032958-16846c6a-66ba-44ce-9217-681fabe64cae.png)

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- src/js/main.js
- src/pages/mainPage.html
- src/styles/components/main.css

## [📝 생성된 파일]

- 없음

## [📌 제안 사항]

- 모두에게 제안하고 싶은 내용을 작성하여 주세요.
- 해당 안건은 회의시간 안건으로 사용됩니다.

## [📢 Notice]

- "예매하기" 버튼의 하단에 불필요한 공간을 li가 차지하는 문제를 해결하기 위하여 li요소에 margin-bottom: auto를 사용하였습니다.

## [이슈 끝내기]
close: #64 
