### PR TITLE
fix: 극장판 소드 아트 온라인과 같이 이미지를 불러올 수 없는 경우 대체 이미지로 적용

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -4,7 +4,7 @@ const fetchAPI = new MovieData();
 const data = await fetchAPI.getMovieData();
 
 const $newItems = document.querySelector(".newItems");
-const replaceImg = "https://unsplash-assets.imgix.net/empty-states/photos.png";
+const replaceImg = "https://t1.daumcdn.net/movie/c171adb6eaa6dff8bb70a1d07e8431e893237c08";
 
 window.addEventListener("load", async () => {
   const boxOfficeMovieInfoArr = [];


### PR DESCRIPTION
# fix: 극장판 소드 아트 온라인과 같이 이미지를 불러올 수 없는 경우 대체 이미지로 적용
#92 

## [🖥️ 스크린샷]

## [⚠️ 삭제된 파일 ]

- 없음

## [✂️ 수정된 파일]

- src/js/main.js

## [📝 생성된 파일]

- 없음

## [📌 제안 사항]

- 모두에게 제안하고 싶은 내용을 작성하여 주세요.
- 해당 안건은 회의시간 안건으로 사용됩니다.

## [📢 Notice]

- fake db.json에 대해서만 유용하게 사용할 수 있습니다.
- 왜냐하면 fake db.json에서만 "극장판 소드 아트 온라인" 영화 이미지만 불러올 수 없기 때문입니다.
- 만일 일반적인 경우를 고려한다면, 불러올 수 없는 모든 이미지에 대해 "극장판 소드 아트 온라인" 이미지가 입혀진다는 이슈가 발생할 수 있습니다. 

## [이슈 끝내기]
close: #92
